### PR TITLE
Update version in sbt installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ package object config extends GenericReader {
 
 You add this library as a sbt dependency:
 ```scala
-libraryDependencies += "org.zalando" %% "grafter" % "1.0.0"
+libraryDependencies += "org.zalando" %% "grafter" % "1.2.6"
 ```
 
 ## Contributing


### PR DESCRIPTION
The version in the README is out of date and causes an error when copying and pasting the sbt instruction to quickly try out grafter.