### PR TITLE
Macro to replace genericReader boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,17 @@ case class ApplicationConfig(
 )
 ```
 
+Another common element is the `implicit def reader` that returns `genericReader`. It is possible to replace the companion object containing this function with a `@reader[A]` annotation on the case class:
+
+```scala
+@reader[ApplicationConfig]
+case class PostgresDatabase(dbConfig: DbConfig) extends Start {
+  def start: Eval[StartResult] =
+    Start.eval("postgres")(PostgresDriver.start(dbConfig.url))
+}
+// no need for the companion object
+```
+
 ### Create the full application
 
 First you need a full `ApplicationConfig`
@@ -282,7 +293,7 @@ package object config extends GenericReader {
 
 You add this library as a sbt dependency:
 ```scala
-libraryDependencies += "org.zalando" %% "grafter" % "1.2.6"
+libraryDependencies += "org.zalando" %% "grafter" % "1.3.0"
 ```
 
 ## Contributing

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ lazy val macros = project.in(file("macros")).
   settings(
     compilationSettings ++
     Seq(publishArtifact := false)
-  )
+  ).dependsOn(core)
 
 lazy val rootSettings = Seq(
   sources in Compile  := sources.all(aggregateCompile).value.flatten,
@@ -35,7 +35,7 @@ lazy val aggregateCompile = ScopeFilter(
 lazy val commonSettings = Seq(
   organization         := "org.zalando",
   name                 := "grafter",
-  version in ThisBuild := "1.2.6"
+  version in ThisBuild := "1.3.0"
 )
 
 lazy val testSettings = Seq(

--- a/macros/src/main/scala/org/zalando/grafter/macros/ReaderMacro.scala
+++ b/macros/src/main/scala/org/zalando/grafter/macros/ReaderMacro.scala
@@ -1,0 +1,75 @@
+package org.zalando.grafter.macros
+
+import scala.annotation.StaticAnnotation
+import scala.language.experimental.macros
+import scala.reflect.macros.whitebox
+
+object ReaderMacro {
+
+  def impl(c: whitebox.Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
+    import c.universe._
+
+    object TypeParamTraverser extends Traverser {
+      var types: List[c.universe.TypeName] = List[TypeName]()
+      override def traverse(tree: Tree): Unit = tree match {
+        case New(AppliedTypeTree(Ident(TypeName("reader")), typeIds)) =>
+          types = typeIds.collect {
+            case Ident(typeName: TypeName) => typeName
+          }
+        case _ => super.traverse(tree)
+      }
+    }
+
+    val inputs : (Tree, Tree, Option[Tree]) =
+      annottees.toList match {
+        case classDecl :: companion :: rest =>
+          (classDecl.tree, c.typecheck(classDecl.tree), Option(companion.tree))
+
+        case classDecl :: rest =>
+          (classDecl.tree, c.typecheck(classDecl.tree), None)
+
+        case Nil => c.abort(c.enclosingPosition, "no target")
+      }
+
+    val outputs: List[Tree] = {
+      val (original, ClassDef(_, className, _, _), companion) = inputs
+
+      val genericReader = {
+        TypeParamTraverser.traverse(c.macroApplication)
+        TypeParamTraverser.types
+          .headOption
+          .map { a =>
+            c.Expr[Any](
+              q"""
+               import org.zalando.grafter.GenericReader._
+               implicit def reader: cats.data.Reader[$a, $className] = genericReader""")
+          }
+          .getOrElse {
+            c.abort(c.enclosingPosition, "The @reader annotation requires a type parameter")
+          }
+      }
+
+      val companionObject = companion match {
+        case Some(q"""object $companionName { ..$body }""") =>
+          q"""object $companionName {
+           ..$body
+           ..$genericReader
+           }"""
+
+        case None =>
+          q"""object ${TermName(className.decodedName.toString)} {
+           ..$genericReader
+           }"""
+      }
+
+      original :: companionObject :: Nil
+    }
+
+    c.Expr[Any](Block(outputs, Literal(Constant(()))))
+  }
+
+}
+
+class reader[A] extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro ReaderMacro.impl
+}

--- a/macros/src/main/scala/org/zalando/grafter/macros/ReadersMacro.scala
+++ b/macros/src/main/scala/org/zalando/grafter/macros/ReadersMacro.scala
@@ -3,7 +3,7 @@ package org.zalando.grafter.macros
 import scala.annotation.StaticAnnotation
 import scala.language.experimental.macros
 
-object ReaderMacro {
+object ReadersMacro {
 
   def impl(c: scala.reflect.macros.whitebox.Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
     import c.universe._
@@ -60,5 +60,5 @@ object ReaderMacro {
 }
 
 class readers extends StaticAnnotation {
-  def macroTransform(annottees: Any*): Any = macro ReaderMacro.impl
+  def macroTransform(annottees: Any*): Any = macro ReadersMacro.impl
 }

--- a/macros/src/test/scala/org/zalando/grafter/macros/ReaderMacroTest.scala
+++ b/macros/src/test/scala/org/zalando/grafter/macros/ReaderMacroTest.scala
@@ -1,0 +1,14 @@
+package org.zalando.grafter.macros
+
+object ReaderMacroTest {
+  val r1: cats.data.Reader[ApplicationConfig, C] = C.reader
+}
+
+case class ApplicationConfig()
+
+@reader[ApplicationConfig]
+case class C()
+
+// This will not compile because the type parameter is missing
+//@reader
+//case class CC()

--- a/macros/src/test/scala/org/zalando/grafter/macros/ReadersMacroTest.scala
+++ b/macros/src/test/scala/org/zalando/grafter/macros/ReadersMacroTest.scala
@@ -1,6 +1,6 @@
 package org.zalando.grafter.macros
 
-object ReaderMacroTest {
+object ReadersMacroTest {
   val r1: cats.data.Reader[AppConfig, C1] =
     AppConfig.c1Reader
 


### PR DESCRIPTION
It is very common to require a companion object that just provides an implicit Reader from the genericReader 

```scala
object PostgresDatabase {
  implicit def reader: Reader[ApplicationConfig, PostgresDatabase] = genericReader
}
```

This PR adds a new macro annotation so that this companion object can be omitted. Instead, the case class should be annotated with the `@reader` annotation, supplying a type parameter that is to be used as the first type parameter of the Reader:

```scala
@reader[ApplicationConfig]
case class PostgresDatabase(dbConfig: DbConfig) extends Start {
```
