### PR TITLE
Add support for traits on readers object

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ package object config extends GenericReader {
 
 You add this library as a sbt dependency:
 ```scala
-libraryDependencies += "org.zalando" %% "grafter" % "1.3.0"
+libraryDependencies += "org.zalando" %% "grafter" % "1.3.1"
 ```
 
 ## Contributing

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ lazy val aggregateCompile = ScopeFilter(
 lazy val commonSettings = Seq(
   organization         := "org.zalando",
   name                 := "grafter",
-  version in ThisBuild := "1.3.0"
+  version in ThisBuild := "1.3.1"
 )
 
 lazy val testSettings = Seq(

--- a/macros/src/main/scala/org/zalando/grafter/macros/ReaderMacro.scala
+++ b/macros/src/main/scala/org/zalando/grafter/macros/ReaderMacro.scala
@@ -50,8 +50,8 @@ object ReaderMacro {
       }
 
       val companionObject = companion match {
-        case Some(q"""object $companionName { ..$body }""") =>
-          q"""object $companionName {
+        case Some(q"""$mod object $companionName extends { ..$earlydefns } with ..$parents { ..$body }""") =>
+          q"""$mod object $companionName extends { ..$earlydefns } with ..$parents {
            ..$body
            ..$genericReader
            }"""

--- a/macros/src/main/scala/org/zalando/grafter/macros/ReadersMacro.scala
+++ b/macros/src/main/scala/org/zalando/grafter/macros/ReadersMacro.scala
@@ -38,8 +38,8 @@ object ReadersMacro {
 
         val companionObject =
         companion match {
-          case Some(q"""object $companionName { ..$body }""") =>
-            q"""object $companionName {
+          case Some(q"""$mod object $companionName extends { ..$earlydefns } with ..$parents { ..$body }""") =>
+            q"""$mod object $companionName extends { ..$earlydefns } with ..$parents {
            ..$body
            ..$readerInstances
            }"""

--- a/macros/src/test/scala/org/zalando/grafter/macros/ReadersMacroTest.scala
+++ b/macros/src/test/scala/org/zalando/grafter/macros/ReadersMacroTest.scala
@@ -11,11 +11,13 @@ object ReadersMacroTest {
 //  val r3: cats.data.Reader[AppConfig, C2] =
 //    AppConfig.c22Reader
 }
+trait T1
+trait T2
 
 @readers
 case class AppConfig(c1: C1, c21: C2, c22: C2)
 
-object AppConfig {
+object AppConfig extends T1 with T2 {
   def prod = AppConfig(C1(), C2(), C2())
 }
 


### PR DESCRIPTION
If the companion object for the Config case class extends something, the `@readers` pattern match will fail.

```scala
case class ApplicationConfig(http: HttpConfig, db:   DbConfig)

object ApplicationConfig extends Logging {
  def apply(): ApplicationConfig = ...
}
```

This PR extends the quasiquotes match of a declared companion object to support the `extends` and `with` keywords.
