### PR TITLE
#15 singletons can be made in any order

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ lazy val aggregateCompile = ScopeFilter(
 lazy val commonSettings = Seq(
   organization         := "org.zalando",
   name                 := "grafter",
-  version in ThisBuild := "1.3.1"
+  version in ThisBuild := "1.3.2"
 )
 
 lazy val testSettings = Seq(

--- a/core/src/main/scala/org/zalando/grafter/Rewriter.scala
+++ b/core/src/main/scala/org/zalando/grafter/Rewriter.scala
@@ -1,7 +1,7 @@
 package org.zalando.grafter
 
 import cats.Eval
-import org.bitbucket.inkytonik.kiama.rewriting.Rewriter._
+import org.bitbucket.inkytonik.kiama.rewriting.MemoRewriter._
 import org.bitbucket.inkytonik.kiama.rewriting.Strategy
 
 import scala.collection.mutable.ListBuffer


### PR DESCRIPTION
Previously a graph with shared nodes might be rewritten as a tree.
With a MemoRewriter instead of a Rewriter this is not the case,
every rewritten node is memoized.

closes #15