### PR TITLE
#20 rewrote the @reader annotation to define a reader directly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ lazy val aggregateCompile = ScopeFilter(
 lazy val commonSettings = Seq(
   organization         := "org.zalando",
   name                 := "grafter",
-  version in ThisBuild := "1.4.8"
+  version in ThisBuild := "1.4.9"
 )
 
 lazy val testSettings = Seq(
@@ -64,6 +64,8 @@ lazy val compilationSettings = Seq(
     "-Ywarn-numeric-widen",
     "-Ywarn-dead-code",
     "-Yno-adapted-args",
+    // to debug the macros
+    //"-Ymacro-debug-lite",
     "-language:_",
     "-target:jvm-1.8",
     "-encoding", "UTF-8"

--- a/macros/src/test/scala/org/zalando/grafter/macros/ReaderMacroTest.scala
+++ b/macros/src/test/scala/org/zalando/grafter/macros/ReaderMacroTest.scala
@@ -1,7 +1,21 @@
 package org.zalando.grafter.macros
 
+import org.specs2.Specification
+
 object ReaderMacroTest {
   val r1: cats.data.Reader[ApplicationConfig, C] = C.reader
+}
+
+class ReaderMacroSpec extends Specification { def is = s2"""
+
+ the reader annotation can be used to declare a reader for a given config type $useAnnotation
+
+"""
+
+  def useAnnotation = {
+    R1.reader.apply(ApplicationConfig()).r3.r4.s ==== "hello"
+  }
+
 }
 
 case class ApplicationConfig()
@@ -9,6 +23,24 @@ case class ApplicationConfig()
 @reader[ApplicationConfig]
 case class C()
 
-// This will not compile because the type parameter is missing
+//This will not compile because the type parameter is missing
 //@reader
 //case class CC()
+
+@reader[ApplicationConfig]
+case class R1(r2: R2, r3: R3, r4: R4) {
+  private val field1 = "should not be used for the reader instance"
+}
+
+@reader[ApplicationConfig]
+case class R2()
+
+@reader[ApplicationConfig]
+case class R3(r4: R4)
+
+case class R4(s: String)
+
+object R4 {
+  implicit def reader: cats.data.Reader[ApplicationConfig, R4] =
+    cats.data.Reader(_ => R4("hello"))
+}


### PR DESCRIPTION
@jcranky @taojang good news, this new annotation is faster than the old one, meaning that there is no degradation of performances compared to using `genericReader`. Unfortunately it is not faster either which is still puzzling to me.

Also I'm quite happy with this encoding because it doesn't change the `implicit def reader: Reader[Config, Component]` signature which we had before. And the error messages with missing implicits should be better!