### PR TITLE
#42 final classes can not be singletons

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,16 @@ val app3: Application =
 ```
 
 Note that `grafter` will only try to make a singleton for classes which are instances of `scala.Product` or 
-which implement Kiama's `org.bitbucket.inkytonik.kiama.rewriting.Rewritable` trait.
+which implement Kiama's `org.bitbucket.inkytonik.kiama.rewriting.Rewritable` trait with the `singletons` method. 
+It will also *not* make singleton for `AnyVal` case classes or `final` case classes. This allows case classes 
+ representing String or Int parameters to *not* be made singletons
+```scala
+
+// instances of these classes will fortunately not
+// be made singletons (otherwise everything will have the same port!)
+case class DbUrl(value: String) extends AnyVal
+case class Port(value: Int) extends AnyVal
+```
 
 ***Very important***
 

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ lazy val aggregateCompile = ScopeFilter(
 lazy val commonSettings = Seq(
   organization         := "org.zalando",
   name                 := "grafter",
-  version in ThisBuild := "1.4.9"
+  version in ThisBuild := "1.4.10"
 )
 
 lazy val testSettings = Seq(

--- a/core/src/main/scala/org/zalando/grafter/Rewriter.scala
+++ b/core/src/main/scala/org/zalando/grafter/Rewriter.scala
@@ -1,5 +1,6 @@
 package org.zalando.grafter
 
+import java.lang.reflect.Modifier
 import cats.Eval
 import org.bitbucket.inkytonik.kiama.rewriting.{MemoRewriter, Rewritable, Strategy}
 
@@ -190,8 +191,8 @@ trait Rewriter {
   }
 
   private def canBeSingleton(v: Any): Boolean = v match {
-    case _ : Rewritable => true
-    case _ : Product    => true
+    case _ : Rewritable => !Modifier.isFinal(v.getClass.getModifiers)
+    case _ : Product    => !Modifier.isFinal(v.getClass.getModifiers)
     case _              => false
   }
 


### PR DESCRIPTION
@taojang @jcranky I think this is a reasonable proposal, especially for `AnyVal` case classes. The only limitation: if a "normal" component is `final` (some people insist on this) then it cannot be made a singleton with the `singletons` method. However it can still be made a singleton with `singleton[Component]`.