### PR TITLE
Tweak the component creation documentation a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Grafter goes back to the fundamentals of dependency injection by *just using con
  - [Components](doc/components.md)
  - [Configuration](doc/config.md)
  - [Creating components](doc/creating.md)
- - [Starting and Stopping an Application](doc/start-stop.md)
  - [Singletons](doc/singletons.md)
+ - [Starting and Stopping an Application](doc/start-stop.md)
  - [Testing](doc/testing.md)
  - [Inspect the App Graph](doc/inspect-app-graph.md)
 

--- a/doc/creating.md
+++ b/doc/creating.md
@@ -1,9 +1,9 @@
 
-### Create other components and use shapeless
+### Creating other components and using shapeless
 
 If a component depends on other components, its `Reader` instance depends on its dependencies
-`Reader` instances. Since this is all recursive and automatable, thanks to Shapeless, we can write
-the following this:
+`Reader` instances. Since this is all recursive and automatable, thanks to Shapeless, we can
+write the following:
 
 ```scala
 import org.zalando.grafter.GenericReader._
@@ -42,10 +42,10 @@ object DbConfig {
 }
 ```
 
-Note that `Application` depends on the `Database` interface. When we create an `Application` instance
-`Database.reader` will be used and will provide a `Postgres` implementation by default. This means that
-there must *always* be a default implementation for each interface introduced in the system. But don't
-worry, we can always change it later!
+Note that `Application` depends on the `Database` interface. When we create an `Application`
+instance, `Database.reader` will be used and will provide a `Postgres` implementation by default.
+This means that there must *always* be a default implementation for each interface introduced
+in the system. But don't worry, we can always change it later!
 
 
 #### Remove dependency on global config
@@ -59,7 +59,8 @@ object HttpServer {
 }
 ```
 
-To avoid this dependency lets parametrize the `reader` with some config of type `A`:
+If you are creating a library, you will probably want to avoid this. To do it, lets parametrize
+the `reader` function with some config of type `A`:
 
 ```scala
 object HttpServer {
@@ -69,8 +70,9 @@ object HttpServer {
 }
 ```
 
-This allows us to put the `HttpServer` into a reusable module and build it independently from the `ApplicationConfig`.
-Next, implicitly provide a `Reader[ApplicationConfing, HttConfig]` and you may create the `HttpServer`.
+This allows us to put the `HttpServer` into a reusable module and build it independently
+from the `ApplicationConfig`. Next, implicitly provide a `Reader[ApplicationConfing, HttpConfig]`
+and you may create the `HttpServer`.
 
 
 #### Create the full application
@@ -84,7 +86,8 @@ val prod: ApplicationConfig = ApplicationConfig(
 )
 ```
 
-Then we can summon the implicit `Reader` instance for `Application` and pass it the "prod" configuration:
+Then we can summon the implicit `Reader` instance for `Application` and pass it the "prod"
+configuration:
 
 ```scala
 val application: Application =


### PR DESCRIPTION
I don't want to change this one too much yet. but my impression is that having an explicit `reader` is sometimes optional and this could be mentioned. In some experimentations I noted that if a given dependency is a `case class` that only contains other `case class`es, you don't need to create the `reader` function due to shapeless magic.