### PR TITLE
#64 use Generic instead of labelled.Generic

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ lazy val aggregateCompile = ScopeFilter(
 lazy val commonSettings = Seq(
   organization         := "org.zalando",
   name                 := "grafter",
-  version in ThisBuild := "1.4.12"
+  version in ThisBuild := "1.5.0"
 )
 
 lazy val testSettings = Seq(

--- a/core/src/main/scala/org/zalando/grafter/GenericReader.scala
+++ b/core/src/main/scala/org/zalando/grafter/GenericReader.scala
@@ -1,7 +1,6 @@
 package org.zalando.grafter
 
 import shapeless._
-import shapeless.labelled._
 import cats.data._
 
 /**
@@ -16,15 +15,13 @@ trait GenericReader {
   implicit def hnilReader[R]: Reader[R, HNil] =
     Reader(_ => HNil)
 
-  implicit def hconsReader[R, K <: Symbol, H, T <: HList](implicit
-                                                           key: Witness.Aux[K],
-                                                           readerHead: Lazy[Reader[R, H]],
-                                                           readerTail: Lazy[Reader[R, T]]
-  ): Reader[R, FieldType[K, H] :: T] =
-    Reader((r: R) => field[K](readerHead.value(r)) :: readerTail.value(r))
+  implicit def hconsReader[R, H, T <: HList](implicit readerHead: Lazy[Reader[R, H]],
+                                                      readerTail: Lazy[Reader[R, T]]
+  ): Reader[R, H :: T] =
+    Reader((r: R) => readerHead.value(r) :: readerTail.value(r))
 
   implicit def genericReader[R, A, Repr](implicit
-    gen: LabelledGeneric.Aux[A, Repr],
+    gen:  Generic.Aux[A, Repr],
     repr: Lazy[Reader[R, Repr]]
   ): Reader[R, A] =
     Reader((r: R) => gen.from(repr.value(r)))

--- a/macros/src/test/scala/org/zalando/grafter/macros/ReaderMacroTest.scala
+++ b/macros/src/test/scala/org/zalando/grafter/macros/ReaderMacroTest.scala
@@ -30,6 +30,7 @@ case class C()
 @reader[ApplicationConfig]
 case class R1(r2: R2, r3: R3, r4: R4) {
   private val field1 = "should not be used for the reader instance"
+  println(field1)
 }
 
 @reader[ApplicationConfig]


### PR DESCRIPTION
@taojang @jcranky please review, I think we can simplify our code and possibly compilation times because of less implicit requirements. 