### PR TITLE
Added a way to discriminate instances when making singletons

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ lazy val aggregateTest = ScopeFilter(
 lazy val commonSettings = Seq(
   organization         := "org.zalando",
   name                 := "grafter",
-  version in ThisBuild := "2.1.1"
+  version in ThisBuild := "2.1.2"
 )
 
 lazy val testSettings = Seq(

--- a/tests/src/test/scala/org/zalando/grafter/RewriterSpec.scala
+++ b/tests/src/test/scala/org/zalando/grafter/RewriterSpec.scala
@@ -11,6 +11,8 @@ class RewriterSpec extends Specification with ThrownExpectations { def is = s2""
  An object graph can be rewritten with a node becoming a singleton object
    All identical nodes (having the same type) are replaced by just the first found instance $makeSingleton
    Singletons can be made according to a predicate                                          $makeSingletonPredicate
+   Singletons can be made according to a partial function discriminating instances          $makeSingletonBy
+   Singletons can be made according to some partial functions discriminating instances      $makeSingletonBys
    Making singletons must not fail on nested classes                                        $makeSingletonNestedClass
    Making singletons must not work on final classes                                         $makeSingletonFinalClass
    Making singletons must not work on AnyVal case classes                                   $makeSingletonAnyValClass
@@ -55,6 +57,30 @@ class RewriterSpec extends Specification with ThrownExpectations { def is = s2""
 
     rewritten.b.d must be(rewritten.c.d)
     rewritten.b.d must_== D("d1")
+  }
+
+  def makeSingletonBy = {
+    val rewritten = graph.singletonsBy {
+      case e: E => e.toString
+    }
+
+    rewritten.b.f must be(rewritten.b.f)
+    rewritten.b.e.toString must_== "e1"
+    rewritten.c.e.toString must_== "e2"
+  }
+
+  def makeSingletonBys = {
+    val byE: PartialFunction[Any, Any] = { case e: E => e.toString }
+    val byD: PartialFunction[Any, Any] = { case d: D => d.toString }
+
+    val rewritten = graph.singletonsBy(byE, byD)
+
+    rewritten.b.f must be(rewritten.b.f)
+    rewritten.b.d.toString must_== "d1"
+    rewritten.c.d.toString must_== "d2"
+
+    rewritten.b.e.toString must_== "e1"
+    rewritten.c.e.toString must_== "e2"
   }
 
   def makeSingletonNestedClass = {


### PR DESCRIPTION
Review @jcranky. This makes working with complicated graphs a lot more predictable. For example
```scala
// put specific configuration everywhere it's needed
t.modifyWith[Any] {
  case c: HttpServer                    => c.replaceFirst(config.serverThreadPool)
  case c: NakadiEventProcessor          => c.replaceFirst(config.nakadiClientThreadPool)
  case c: Http4sClient                  => c.replace(config.clientThreadPool)
  case c: DoobieDatabase                => c.replace(config.databaseThreadPool)
  case c: NakadiHttp4sSubscription      => c.replaceFirst(config.nakadiHttpClientConfig)
  case c: BusinessPartnerServiceDefault => c.replaceFirst(config.businessPartnerRefreshConfig)
  case c: ZeosTranslationDefault        => c.replaceFirst(config.translationSoapConfig)
  case c: ProductDataDefault            => c.replace(config.productCacheConfig)
  case c: ZeosCatalogDefault            => c.replaceFirst(config.catalogSoapConfig)
  case c: MasterDataDefault             => c.replaceFirst(config.clientThreadPool)
                                            .replaceFirst(config.translationCacheConfig)
                                            .replaceFirst(config.catalogRefreshConfig)
// make singletons, keeping specific instances
// when there's some specific configuration
}.singletonsBy(
  httpClientSingleton,
  cacheSingleton,
  zeosInterfaceSingleton,
  executionServiceSingleton)
```
And the following definitions can be put in their respective libraries
```scala
val httpClientSingleton: PartialFunction[Any, Any] = {
  case c: HttpClientConfig => c
  case c: Http4sClient     => c.config
}

val cacheSingleton: PartialFunction[Any, Any] = {
  case c: CacheConfig   => c
  case c: CaffeineCache => c.config
}

val zeosInterfaceSingleton: PartialFunction[Any, Any] = {
  case c: SoapClientConfig     => c
  case c: ZeosInterfaceDefault => c.soapClientConfig
}

val executionServiceSingleton: PartialFunction[Any, Any] = {
  case c: ThreadPoolConfig       => c
  case c: ExecutionService       => c.config
  case c: ScalazAsyncTaskService => c.executionService.config
}
```