### PR TITLE
Removed AnyVals from the generated visualization

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ lazy val aggregateTest = ScopeFilter(
 lazy val commonSettings = Seq(
   organization         := "org.zalando",
   name                 := "grafter",
-  version in ThisBuild := "2.1.2"
+  version in ThisBuild := "2.1.3"
 )
 
 lazy val testSettings = Seq(

--- a/core/src/main/scala/org/zalando/grafter/Queries.scala
+++ b/core/src/main/scala/org/zalando/grafter/Queries.scala
@@ -1,5 +1,7 @@
 package org.zalando.grafter
 
+import java.lang.reflect.Modifier
+
 import org.bitbucket.inkytonik.kiama.rewriting.MemoRewriter._
 
 import scala.collection.mutable.ListBuffer
@@ -72,7 +74,18 @@ trait Query {
   }
 
   def relation[G <: Product](graph: G, filter: Product => Boolean = (_:Product) => true): Relation[Product, Product] =
-    Relation.fromOneStep(graph, g => TreeRelation.treeChildren(g).filter(filter))
+    Relation.fromOneStep(graph, g => TreeRelation.treeChildren(g).filterNot(isAnyVal).filter(filter))
+
+
+  private def isAnyVal[T](t: T): Boolean = {
+    val klass = t.getClass
+    t match {
+      case p: Product if Modifier.isFinal(klass.getModifiers) && p.productArity == 1 =>
+        true
+      case _ =>
+        false
+    }
+  }
 
 }
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -4,10 +4,10 @@
 To use Grafter you can add it as a dependency in your sbt build settings:
 
 ```scala
-libraryDependencies += "org.zalando" %% "grafter" % "2.1.1"
+libraryDependencies += "org.zalando" %% "grafter" % "2.1.3"
 
 // if you use the ComponentsMatchers
-libraryDependencies += "org.zalando" %% "grafter" % "2.1.1" % "test" classifier "tests"
+libraryDependencies += "org.zalando" %% "grafter" % "2.1.3" % "test" classifier "tests"
 ```
 
 Grafter also provides some annotations to help reducing the boilerplate in

--- a/tests/src/test/scala/org/zalando/grafter/VisualizeSpec.scala
+++ b/tests/src/test/scala/org/zalando/grafter/VisualizeSpec.scala
@@ -10,7 +10,7 @@ class VisualizeSpec extends Specification with ThrownExpectations { def is = s2"
 
  The example graph must be correctly serialized into .dot format $s1
  A package filter can be used to only keep specified classes in the resulting graph $s2
-
+ AnyVals must not appear in the visualization $s3
 """
   import Graph._
 
@@ -59,6 +59,20 @@ class VisualizeSpec extends Specification with ThrownExpectations { def is = s2"
           |}""".stripMargin
   }
 
+  def s3 = {
+
+    val app = F(A(), G("name"))
+
+    val dot = app.asDotString
+
+    dot ====
+      s"""|strict digraph {
+          |  "A" [shape=box];
+          |  "F" [shape=box];
+          |  "F" -> "A"
+          |}""".stripMargin
+  }
+
 }
 
 object Graph {
@@ -67,6 +81,8 @@ object Graph {
   case class B(a: A)
   case class C(a: A, b1: B, b2: B)
   case class D(c1: C, c2: C)
-
   case class E(a: A, foo: Foo)
+  case class F(a: A, g: G)
+  case class G(name: String) extends AnyVal
+
 }


### PR DESCRIPTION
Small PR to remove AnyVals from the generated dot graph (cf all the "ExecutorName" nodes appearing in tinbox).

Review @jcranky 