### PR TITLE
Added support for parametrized case classes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ lazy val aggregateTest = ScopeFilter(
 lazy val commonSettings = Seq(
   organization         := "org.zalando",
   name                 := "grafter",
-  version in ThisBuild := "2.3.0"
+  version in ThisBuild := "2.4.0"
 )
 
 lazy val testSettings = Seq(

--- a/depend.sbt
+++ b/depend.sbt
@@ -1,7 +1,7 @@
 
 lazy val catsVersion       = "0.9.0"
 lazy val kiamaVersion      = "2.1.0"
-lazy val specs2Version     = "4.0.0-RC3"
+lazy val specs2Version     = "4.0.1"
 lazy val shapelessVersion  = "2.3.2"
 
 libraryDependencies in Global ++=

--- a/macros/src/main/scala/org/zalando/grafter/macros/ReaderMacros.scala
+++ b/macros/src/main/scala/org/zalando/grafter/macros/ReaderMacros.scala
@@ -53,7 +53,14 @@ object ReaderMacros {
 
   def fieldsNamesAndTypes(c: whitebox.Context)(fields: List[c.universe.Tree]): List[(c.universe.TermName, c.universe.Tree)] = {
     import c.universe._
-    fields.collect { case ValDef(mods, fieldName, fieldType, _) if mods.hasFlag(Flag.CASEACCESSOR) =>
+    fields.collect { case ValDef(mods, fieldName, fieldType, _) if mods.hasFlag(Flag.CASEACCESSOR) && !mods.hasFlag(Flag.IMPLICIT) =>
+      (fieldName, fieldType)
+    }
+  }
+
+  def implicitFieldsNamesAndTypes(c: whitebox.Context)(fields: List[c.universe.Tree]): List[(c.universe.TermName, c.universe.Tree)] = {
+    import c.universe._
+    fields.collect { case ValDef(mods, fieldName, fieldType, _) if mods.hasFlag(Flag.CASEACCESSOR) && mods.hasFlag(Flag.IMPLICIT) =>
       (fieldName, fieldType)
     }
   }

--- a/macros/src/test/scala/org/zalando/grafter/macros/ReaderFMacroTest.scala
+++ b/macros/src/test/scala/org/zalando/grafter/macros/ReaderFMacroTest.scala
@@ -1,0 +1,40 @@
+package org.zalando.grafter.macros
+
+import cats.Monad
+import cats.implicits._
+
+object ReaderFMacroTest {
+  @readers
+  case class Config(n: Int)
+
+  val rc0: cats.data.Reader[Config, FinallyTaglessDefault[Option]] =
+    implicitly[cats.data.Reader[Config, FinallyTaglessDefault[Option]]]
+
+  val rc1: cats.data.Reader[Config, FT1[Option]] =
+    implicitly[cats.data.Reader[Config, FT1[Option]]]
+
+}
+
+@defaultReader[FinallyTaglessDefault]
+trait FinallyTagless[F[_]] {
+  def getIt(id: Int): F[Option[String]]
+}
+
+@reader
+case class FinallyTaglessDefault[F[_]](ft1: FT1[F], ft2: FT2[F])(implicit val m: Monad[F]) extends FinallyTagless[F] {
+  def getIt(id: Int): F[Option[String]] =
+    if (id % 2 == 0) ft1.getEven(id)
+    else ft2.getOdd(id)
+}
+
+@reader
+case class FT1[F[_]](n: Int)(implicit val m: Monad[F]) {
+  def getEven(id: Int): F[Option[String]] =
+    Monad[F].pure(None)
+}
+
+@reader
+case class FT2[F[_]]()(implicit val m: Monad[F]) {
+  def getOdd(id: Int): F[Option[String]] =
+    Monad[F].pure(None)
+}


### PR DESCRIPTION
This allows to support the "finally tagless" style where a case class is parametrized by a type constructor used to constraint return values.

There is unfortunately a syntactic limitation due to a [bug in scala macros](https://github.com/scala/bug/issues/10589):

```scala
@reader
case class FT1[F[_]](n: Int)(implicit val m: Monad[F])

// instead of 
@reader
case class FT1[F[_] : Monad](n: Int)
```

Review @danielkarch @jcranky 